### PR TITLE
Repair function prototypes in the .h Files

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -23,7 +23,7 @@ typedef struct {
  * and writes them to a configuration file. This function is called
  * by get_config if no existing configuration file is found.
  */
-void create_config(){}
+void create_config();
 
 /**
  * @brief Reads simulation parameters from the configuration file.
@@ -34,7 +34,7 @@ void create_config(){}
  *
  * @param[out] config Pointer to the SimConfig structure to be populated
  */
-void get_config(SimConfig *ptr_config){}
+void get_config(SimConfig *ptr_config);
 
 /**
  * @brief Saves the current simulation configuration to a file.
@@ -44,4 +44,4 @@ void get_config(SimConfig *ptr_config){}
  *
  * @param[in] config Pointer to the SimConfig structure to be saved
  */
-void save_config(SimConfig *ptr_config){}
+void save_config(SimConfig *ptr_config);

--- a/include/parking.h
+++ b/include/parking.h
@@ -40,7 +40,7 @@ typedef struct {
  * @param[in]     vehicle  Pointer to the vehicle entering the parking lot
  * @param[in,out] simstats Pointer to the current simulation statistics
  */
-void entry_parking(Parking *ptr_parking, Vehicle *ptr_vehicle, SimStats *ptr_simstats) {}
+void entry_parking(Parking *ptr_parking, Vehicle *ptr_vehicle, SimStats *ptr_simstats);
 
 /**
  * @brief Checks all parking spots for vehicles that have exceeded their parking duration.
@@ -52,4 +52,4 @@ void entry_parking(Parking *ptr_parking, Vehicle *ptr_vehicle, SimStats *ptr_sim
  * @param[in,out] parking  Pointer to the parking lot structure
  * @param[in,out] simstats Pointer to the current simulation statistics
  */
-void check_exit(Parking *ptr_parking, SimStats *ptr_simstats){}
+void check_exit(Parking *ptr_parking, SimStats *ptr_simstats);

--- a/include/queue.h
+++ b/include/queue.h
@@ -26,7 +26,7 @@ typedef struct {
  *
  * @param[out] queue Pointer to the queue to be initialized
  */
-void init_queue(Queue *ptr_queue){}
+void init_queue(Queue *ptr_queue);
 
 /**
  * @brief Adds a vehicle to the end of the waiting queue.
@@ -37,7 +37,7 @@ void init_queue(Queue *ptr_queue){}
  * @param[in,out] queue   Pointer to the waiting queue
  * @param[in]     vehicle Pointer to the vehicle to be enqueued
  */
-void enqueue(Queue *ptr_queue, Vehicle *ptr_vehicle){}
+void enqueue(Queue *ptr_queue, Vehicle *ptr_vehicle);
 
 /**
  * @brief Removes and returns the first vehicle from the waiting queue.
@@ -51,7 +51,7 @@ void enqueue(Queue *ptr_queue, Vehicle *ptr_vehicle){}
  * @return Pointer to the next vehicle allowed to enter the parking lot,
  *         or NULL if the queue is empty
  */
-Vehicle *dequeue(Queue *ptr_queue){}
+Vehicle *dequeue(Queue *ptr_queue);
 
 /**
  * @brief Frees all resources associated with the queue.
@@ -63,4 +63,4 @@ Vehicle *dequeue(Queue *ptr_queue){}
  *
  * @param[in,out] queue Pointer to the queue to be deleted
  */
-void delete_queue(Queue *ptr_queue){}
+void delete_queue(Queue *ptr_queue);

--- a/include/stats.h
+++ b/include/stats.h
@@ -24,7 +24,7 @@ typedef struct {
  *
  * @param[out] simstats Pointer to the SimStats structure to be initialized
  */
-void init_simstats(SimStats *ptr_simstats){}
+void init_simstats(SimStats *ptr_simstats);
 
 /**
  * @brief Updates the simulation statistics for the current time step.
@@ -36,7 +36,7 @@ void init_simstats(SimStats *ptr_simstats){}
  * @param[in]     parking  Pointer to the current parking lot state
  * @param[in]     queue    Pointer to the current waiting queue state
  */
-void update_simstats(SimStats *ptr_simstats, Parking *ptr_parking, Queue *ptr_queue){}
+void update_simstats(SimStats *ptr_simstats, Parking *ptr_parking, Queue *ptr_queue);
 
 /**
  * @brief Logs the statistics of the current time step to console and file.
@@ -47,7 +47,7 @@ void update_simstats(SimStats *ptr_simstats, Parking *ptr_parking, Queue *ptr_qu
  *
  * @param[in] simstats Pointer to the SimStats structure of the current step
  */
-void log_step_stats(SimStats *ptr_simstats){}
+void log_step_stats(SimStats *ptr_simstats);
 
 /**
  * @brief Logs the overall simulation statistics to console and file.
@@ -57,6 +57,6 @@ void log_step_stats(SimStats *ptr_simstats){}
  *
  * @param[in] simstats Pointer to the SimStats structure containing all data
  */
-void log_final_stats(SimStats *ptr_simstats){}
+void log_final_stats(SimStats *ptr_simstats);
 
 #endif // STATS_H

--- a/include/vehicle.h
+++ b/include/vehicle.h
@@ -8,4 +8,4 @@ typedef struct {
     unsigned int queue_time;       /**< Number of simulation steps the vehicle spent waiting in the queue. */
 } Vehicle;
 
-void init_vehicle(Vehicle *ptr_vehicle) {}
+void init_vehicle(Vehicle *ptr_vehicle);


### PR DESCRIPTION
Fixed function prototypes in .h files: replaced incorrect definitions (`void XXX() {}`) with proper prototypes (`void XXX();`).