### PR TITLE
Add function rand_arrival in simulation.c

### DIFF
--- a/src/simulation.c
+++ b/src/simulation.c
@@ -8,7 +8,7 @@ FUNCTION rand_arrival(ptr_config : SimConfig*) RETURNS int
     CALL srand(ptr_config->seed)
     rand_i = (CALL rand() % 100) + 1
     
-    IF rand_i > config->arrival_probability_percent DO
+    IF rand_i <= config->arrival_probability_percent DO
         RETURN 1
     ENDIF
 


### PR DESCRIPTION
Generates a random number between 1 and 100 and compares it with the user-specified arrival probability. Returns 1 if the random number is larger than the probability (indicating a vehicle arrives), and 0 otherwise.