### PR TITLE
Add avg_rel_occupancy to stats

### DIFF
--- a/include/stats.h
+++ b/include/stats.h
@@ -32,6 +32,7 @@ typedef struct {
     unsigned int total_queue_time;              /**< Sum of all queue waiting times (in steps). */
     unsigned int total_parking_time;            /**< Sum of all parking durations (in steps). */
     unsigned int time_full_occupancy;           /**< Steps where parking was at full capacity. */
+    float        avg_rel_occupancy;             /**< Average relative occupancy over all steps. */
 
     /* --- Tracked extremes for final report --- */
     unsigned int peak_queue_length;             /**< Peak queue length observed. */

--- a/src/stats.c
+++ b/src/stats.c
@@ -78,6 +78,12 @@ FUNCTION update_simstats(SimStats (Adress)ptr_simstats, Parking (Adress)ptr_park
         ptr_simstats->temp_rel_occupancy_percent = 0
     ENDIF
 
+    // running average formular to add the rel. occupancy of the step to the avg.
+    ptr_simstats->avg_rel_occupancy =
+    (ptr_simstats->avg_rel_occupancy * ptr_simstats->step_num
+     + ptr_simstats->temp_rel_occupancy_percent)
+    / (ptr_simstats->step_num + 1)
+
     IF ptr_parking->occupied_count == ptr_parking->total_capacity THEN
         ptr_simstats->time_full_occupancy = ptr_simstats->time_full_occupancy + 1
     END IF
@@ -186,6 +192,7 @@ FUNCTION reset_all_stats(SimStats (Adress)ptr_simstats)
     ptr_simstats->total_queue_time = 0
     ptr_simstats->total_parking_time = 0
     ptr_simstats->time_full_occupancy = 0
+    ptr_simstats->avg_rel_occupancy = 0.0
     ptr_simstats->peak_queue_length = 0
     ptr_simstats->step_longest_queue = 0
     ptr_simstats->peak_rel_occupancy = 0


### PR DESCRIPTION
Added the avg_rel_occupancy param to the SimStats Structure to track the relative occupancy during the simulation and to get the average relative occupancy at the end using a running average formula adding the temp relative occupancy of the current step to the average.